### PR TITLE
Bump github action versions

### DIFF
--- a/.github/workflows/dockerhub_readme.yml
+++ b/.github/workflows/dockerhub_readme.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Sync Readme
         uses: lablans/sync-dockerhub-readme@feature/replace-patterns
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: EmbarkStudios/cargo-deny-action@v1
+    - uses: actions/checkout@v4
+    - uses: EmbarkStudios/cargo-deny-action@v2
 
   build-rust:
     name: Build (Rust)
@@ -60,7 +60,7 @@ jobs:
           else
             echo "profilestr=--profile $PROFILE" >> $GITHUB_ENV
           fi
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -77,7 +77,7 @@ jobs:
           command: build
           args: --target ${{ env.rustarch }} ${{ env.profilestr }}
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: binaries-${{ matrix.arch }}
           path: |

--- a/.github/workflows/rust_security.yml
+++ b/.github/workflows/rust_security.yml
@@ -5,7 +5,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Some of the currently explicitly set `deny.toml` options became default with the new version, however, as this breaks nothing to set them specifically, I left the file unchanged.